### PR TITLE
bug: sometimes the circuit is created elsewhere, e.g. Azure VMWare

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "express_route_circuit_name" {
   description = "The name of the Express Route Circuit"
-  value       = azurerm_express_route_circuit.this[0].name
+  value       = length(azurerm_express_route_circuit.this) > 0 ? azurerm_express_route_circuit.this[0].name : null
 }
 
 output "express_route_circuit_id" {
   description = "The ID of the Express Route Circuit"
-  value       = azurerm_express_route_circuit.this[0].id
+  value       = length(azurerm_express_route_circuit.this) > 0 ? azurerm_express_route_circuit.this[0].id : null
 }
 
 output "express_route_circuit_peering_id" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
* modified output for express_route_circuit

**:rocket: Motivation**
* fixes errors on output when deploying ExpressRoute Gateway and Connection without Circuit (this happens e.g. when deploying expressroute for Azure VMWare Solution where the circuit is created by AVS)