### PR TITLE
feat: Added routing weight in express route connection.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,5 +58,6 @@ resource "azurerm_express_route_connection" "this" {
   express_route_gateway_id         = coalesce(length(azurerm_express_route_gateway.this) > 0 ? azurerm_express_route_gateway.this[0].id : null, var.express_route_gateway_connection.express_route_gateway_id)
   express_route_circuit_peering_id = coalesce(length(azurerm_express_route_circuit_peering.this) > 0 ? azurerm_express_route_circuit_peering.this[0].id : null, var.express_route_gateway_connection.express_route_circuit_peering_id)
   authorization_key                = var.express_route_gateway_connection.authorization_key
+  routing_weight                   = var.express_route_gateway_connection.routing_weight
 }
 


### PR DESCRIPTION
:hammer_and_wrench: Summary
Added routing_weight parameter support to the ExpressRoute connection resource in Terraform. This allows users to configure the routing weight on ExpressRoute connections, enabling fine-grained control over route preference when multiple ExpressRoute circuits are present.
:rocket: Motivation
When multiple ExpressRoute connections exist within a Virtual WAN hub, Azure uses routing weight to determine the preferred path for traffic. Without the ability to set routing_weight, all connections default to the same weight, leaving no way to influence routing priority through Terraform. This change exposes the routing_weight attribute so teams can define traffic routing preferences declaratively in their infrastructure-as-code.
:pencil: Additional Information

The routing_weight attribute is an optional parameter with a sensible default (e.g. 0) so existing deployments are not impacted
Azure documentation reference: https://learn.microsoft.com/en-us/azure/virtual-wan/virtual-wan-expressroute-portal
The attribute maps directly to the routing_weight property on the azurerm_express_route_connection Terraform resource — see [Terraform Registry docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/express_route_connection#routing_weight)
No breaking changes — fully backwards compatible with existing configurations